### PR TITLE
Switch to sandi

### DIFF
--- a/Network/AWS/Authentication.hs
+++ b/Network/AWS/Authentication.hs
@@ -54,6 +54,14 @@ import Text.XML.HXT.DOM.XmlKeywords
 import Text.XML.HXT.Arrow.XmlState
 import Text.XML.HXT.Arrow.ReadDocument
 
+either f _ (Left x)  = f x
+either _ g (Right y) = g y
+
+rightToMaybe = either (const Nothing) Just
+
+encodeBS = unpack . encode . pack
+decodeBS = rightToMaybe . unpack . decode . pack
+
 -- | An action to be performed using S3.
 data S3Action =
     S3Action {
@@ -121,7 +129,7 @@ makeSignature :: AWSConnection -- ^ Action with authentication data
               -> String -- ^ String to sign
               -> String -- ^ Base-64 encoded signature
 makeSignature c s =
-        encode (hmac_sha1 keyOctets msgOctets)
+        encodeBS (hmac_sha1 keyOctets msgOctets)
         where keyOctets = string2words (awsSecretKey c)
               msgOctets = string2words s
 
@@ -387,7 +395,7 @@ mimeDecodeQP' [] = []
 
 mimeDecodeB64 :: String -> String
 mimeDecodeB64 s =
-    case decode s of
+    case decodeBS s of
         Nothing -> ""
         Just a ->  US.decode a
 

--- a/Network/AWS/Authentication.hs
+++ b/Network/AWS/Authentication.hs
@@ -55,7 +55,7 @@ import Text.XML.HXT.Arrow.XmlState
 import Text.XML.HXT.Arrow.ReadDocument
 
 rightToMaybe = either (const Nothing) Just
-encodeBS = unpack . encode . pack
+encodeBS = unpack . encode . US.decode . pack
 decodeBS = fmap unpack . rightToMaybe . decode . pack
 
 -- | An action to be performed using S3.
@@ -390,10 +390,7 @@ mimeDecodeQP' (h:t) =h : mimeDecodeQP' t
 mimeDecodeQP' [] = []
 
 mimeDecodeB64 :: String -> String
-mimeDecodeB64 s =
-    case decodeBS s of
-        Nothing -> ""
-        Just a ->  US.decode a
+mimeDecodeB64 = maybe "" decodeBS
 
  -- Encode a String into quoted printable, if needed.
  -- eq: =?UTF-8?Q?=aa?=

--- a/Network/AWS/Authentication.hs
+++ b/Network/AWS/Authentication.hs
@@ -55,7 +55,7 @@ import Text.XML.HXT.Arrow.XmlState
 import Text.XML.HXT.Arrow.ReadDocument
 
 rightToMaybe = either (const Nothing) Just
-encodeBS = unpack . encode . US.decode . pack
+encodeBS = unpack . encode . pack . US.decode
 decodeBS = fmap unpack . rightToMaybe . decode . pack
 
 -- | An action to be performed using S3.
@@ -390,7 +390,7 @@ mimeDecodeQP' (h:t) =h : mimeDecodeQP' t
 mimeDecodeQP' [] = []
 
 mimeDecodeB64 :: String -> String
-mimeDecodeB64 = maybe "" decodeBS
+mimeDecodeB64 = maybe "" id . decodeBS
 
  -- Encode a String into quoted printable, if needed.
  -- eq: =?UTF-8?Q?=aa?=

--- a/Network/AWS/Authentication.hs
+++ b/Network/AWS/Authentication.hs
@@ -56,7 +56,7 @@ import Text.XML.HXT.Arrow.ReadDocument
 
 rightToMaybe = either (const Nothing) Just
 encodeBS = unpack . encode . pack
-decodeBS = rightToMaybe . unpack . decode . pack
+decodeBS = fmap unpack . rightToMaybe . decode . pack
 
 -- | An action to be performed using S3.
 data S3Action =

--- a/Network/AWS/Authentication.hs
+++ b/Network/AWS/Authentication.hs
@@ -54,11 +54,7 @@ import Text.XML.HXT.DOM.XmlKeywords
 import Text.XML.HXT.Arrow.XmlState
 import Text.XML.HXT.Arrow.ReadDocument
 
-either f _ (Left x)  = f x
-either _ g (Right y) = g y
-
 rightToMaybe = either (const Nothing) Just
-
 encodeBS = unpack . encode . pack
 decodeBS = rightToMaybe . unpack . decode . pack
 

--- a/Network/AWS/S3Object.hs
+++ b/Network/AWS/S3Object.hs
@@ -28,10 +28,13 @@ import System.Time
 import Data.List.Utils
 import Data.List(lookup)
 import Data.Digest.MD5(hash)
+import Data.Word (Word8)
 import Codec.Binary.Base64 (encode)
 
 import qualified Data.ByteString.Lazy.Char8 as L
 import qualified Data.ByteString.Lazy as LO
+
+import qualified Codec.Binary.UTF8.String as US
 
 -- | An object that can be stored and retrieved from S3.
 data S3Object =
@@ -123,7 +126,7 @@ sendObjectMIC :: AWSConnection      -- ^ AWS connection information
 sendObjectMIC aws obj = sendObject aws obj_w_header where
     obj_w_header = obj { obj_headers = (obj_headers obj) ++ md5_header }
     md5_header = [("Content-MD5", (mkMD5 (obj_data obj)))]
-    mkMD5 = L.unpack . encode . L.pack . hash . LO.unpack
+    mkMD5 = L.unpack . L.fromStrict . encode . LO.toStrict . LO.pack . hash . US.encode . L.unpack
 
 -- | Create a pre-signed request URI.  Anyone can use this to request
 --   an object until the specified date.

--- a/Network/AWS/S3Object.hs
+++ b/Network/AWS/S3Object.hs
@@ -123,7 +123,7 @@ sendObjectMIC :: AWSConnection      -- ^ AWS connection information
 sendObjectMIC aws obj = sendObject aws obj_w_header where
     obj_w_header = obj { obj_headers = (obj_headers obj) ++ md5_header }
     md5_header = [("Content-MD5", (mkMD5 (obj_data obj)))]
-    mkMD5 = encode . hash . LO.unpack
+    mkMD5 = L.unpack . encode . L.pack . hash . LO.unpack
 
 -- | Create a pre-signed request URI.  Anyone can use this to request
 --   an object until the specified date.

--- a/hS3.cabal
+++ b/hS3.cabal
@@ -1,5 +1,5 @@
 Name:           hS3
-Version:        0.5.9
+Version:        0.5.10
 License:        BSD3
 License-file:   LICENSE
 Cabal-Version: >= 1.6

--- a/hS3.cabal
+++ b/hS3.cabal
@@ -36,7 +36,7 @@ source-repository head
 
 Library
   Build-depends:  base >= 3 && < 5, HTTP >= 4000.0.0, Crypto >= 4.1.0, hxt >= 9.0.0 && < 10, network,
-                regex-compat, old-time, random, old-locale, dataenc, utf8-string, bytestring,
+                regex-compat, old-time, random, old-locale, sandi, utf8-string, bytestring,
                 MissingH >= 0.18.6
 
   if flag(network-uri)


### PR DESCRIPTION
`dataenc` is no longer supported, and cannot build against newer versions of base.

This patch replaces the use of `dataenc` with `sandi`, and it attempts to be as un-intrusive as possible.

There may be a case for converting some of the types from String to ByteString which could remove some of the conversion backflips needed, but I feel that is out of scope for this change.

Bumps version to `0.5.10` in the `.cabal` file.